### PR TITLE
httpOnly en true y token desde res.data

### DIFF
--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -14,8 +14,10 @@ const LoginPage = () => {
       const res = await loginRequest(data);
       console.log('soy res: ', res);
 
-      const token = Cookies.get('token');
-      console.log("token: ", token);
+       // Intento de obtener el token desde la respuesta directamente
+       const token = res.data.token || Cookies.get('token');
+       console.log('soy res.data.token: ', res.data.token);
+       console.log("token: ", token);
 
       if (token) {
         login(token);

--- a/server/src/App.js
+++ b/server/src/App.js
@@ -23,5 +23,9 @@ app.use(cookieParser());
 app.use("/api", authRoutes);
 app.use("/api", taskRoutes);
 
+app.get('/', (req, res) => {
+  res.status(200).send('SPA-Tasks API');
+});
+
 export default app;
 

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -84,10 +84,9 @@ export const login = async (req, res) => {
 
     
     res.cookie('token', token, {
-      httpOnly: false, 
+      httpOnly: true, 
       secure: true, 
       sameSite: 'none',
-      partitioned: true
     });
     res.json({
       id: userFound._id,


### PR DESCRIPTION
#24 
- se intentará obtener token directamente desde res.data
- se hace un cambio en App express para evitar un error 404 al consulta /
- se edita el controlador de login eliminando partitioned: true y cambiando httpOnly a true
