### PR TITLE
(rigobersio)edit:render.yaml(routes a index.html)

### DIFF
--- a/client/render.yaml
+++ b/client/render.yaml
@@ -4,3 +4,7 @@ services:
     env: static
     staticPublishPath: build
     buildCommand: npm install && npm run build
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
redirigir a index.html cuando la SPA pierde la gestión de las rutas

Cuando el usuario recarga la página distinta de https://spa-tasks.onrender.com/ o ocupa la barra del navegador para ir a determinada vista de la SPA el navegador hace una solicitud HTTP GET al servidor y dado que esa ruta no está en el hosting statico de render (no tiene un archivo asociado a esa ruta) responde con 404 (Not Found)

hay que indicarle a render que redirija a /index.html en las rutas desconocidas para que la SPA vuelva a tomar control de las rutas

--
Los cambios implementados no han surtido efecto por lo cual se hace necesario eliminar el despliegue y volverlo a crear con la misma configuración: aun después de esto el problema persiste

para solucionar esto se gestionara el archivo vite.config.js en el siguiente pf si esto no resuelve el problema se intentará una solución desde el back