### PR TITLE
new:static.json;edit:AppExpress(static para render y // para path

### DIFF
--- a/client/static.json
+++ b/client/static.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "**",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/server/src/App.js
+++ b/server/src/App.js
@@ -2,7 +2,7 @@ import express from 'express';
 import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
-import path from 'path';
+//import path from 'path';
 
 import authRoutes from "./routes/auth.routes.js";
 import taskRoutes from "./routes/tasks.routes.js";
@@ -28,10 +28,11 @@ app.use("/api", taskRoutes);
 
 
 // Ruta catch-all para servir "index.html"(front) en cualquier otra ruta no gestionada por el backend
+/*
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'build', 'index.html'));
 });
-
+*/
 app.get('/', (req, res) => {
   res.status(200).send('SPA-Tasks API');
 });


### PR DESCRIPTION
se agrega otro archivo de configuración en el front para render y se comenta path en el back

--- al hacer las ultimas pruebas se confirmo que el problema el router de render se soluciono pero el script del archivo 
static.json:
```bash
{
  "rewrites": [
    {
      "source": "**",
      "destination": "/index.html"
    }
  ]
}
```
 o la propiedad  routes de render.yaml

```bash
services:
  - type: web
    name: spa-tasks
    env: static
    staticPublishPath: build
    buildCommand: npm install && npm run build
    routes:
      - type: rewrite
        source: /*
        destination: /index.html
```
no surtieron efecto, sin embargo, en el panel del despliegue `Redirect and Rewrite Rules`  se puede añadir la regla de redireccionado para cuando render no reconoce la ruta porque el router de la SPA perdio la pista por recarga o navegación por url desde la barra de direcciones del navegador
#36 

![imagen](https://github.com/user-attachments/assets/ed5b1f93-d11a-4e8a-af05-7c496e07cfb8)
