### PR TITLE
(ri)edit:LogoutPage(nuevo ajuste-my- items)

### DIFF
--- a/client/src/pages/LogoutPage.jsx
+++ b/client/src/pages/LogoutPage.jsx
@@ -38,13 +38,13 @@ const LogoutPage = () => {
         </p>
       </div>
       <div className="flex flex-col lg:flex-row justify-center items-center lg:px-14 py-12 w-full gap-20">
-        <div className="lg:ml-10 m-3 w-[70%] sm:w-[50%] lg:w-[30%] lg:my-[95%] border-2 border-solid border-fuchsia-600 bg-[#5D9C59] text-white rounded-md">
-          <h2 className="text-2xl font-bold lg:my-12 my-3 text-center">Logout</h2>
+        <div className="lg:ml-10 m-3 w-[70%] sm:w-[50%] lg:w-[25%] border-2 border-solid border-fuchsia-600 bg-[#5D9C59] text-white rounded-md">
+          <h2 className="text-2xl font-bold my-3 text-center">Logout</h2>
           <div className="flex justify-center lg:pt-8 lg:mt-12 pb-5 lg:mb-2">
             <button
               onClick={handleLogout}
               disabled={isSubmitting}
-              className="bg-white text-[#5D9C59] lg:py-4 py-2 px-12 rounded-md shadow-md hover:bg-gray-100 transition duration-300"
+              className="bg-white text-[#5D9C59] py-2 px-12 rounded-md shadow-md hover:bg-gray-100 transition duration-300"
             >
               {isSubmitting ? 'Logging out...' : <strong>Logout</strong>}
             </button>


### PR DESCRIPTION
finalmente se ha determinado que el error en altura máxima es provocado por los margenes o padding de los items presentes en el contenedor