### PR TITLE
(rig)edit:Tasks&&newTask(extraer date con split ok)

### DIFF
--- a/client/src/pages/TasksPage.jsx
+++ b/client/src/pages/TasksPage.jsx
@@ -162,10 +162,12 @@ const TasksPage = () => {
                   {tasks.map(task => (
                     <li key={task._id} className="mb-4 p-4 border rounded-lg shadow-sm bg-white transition hover:bg-slate-100" onClick={() => handleTaskClick(task._id)}>
                       <h3 className="text-xl font-semibold">{task.title}</h3>
-                      <p>{task.date}</p>
+                      {
+                      /*<p>{task.date}</p>
                       {console.log("soy typeof date: ",typeof task.date)}
+                      */}
                       <p>{task.date.split("T")[0]}</p>
-                      {/*<p>data más tolocaledata: {task.date.toLocaleDateString()}</p>*/}
+                    
                       {/*<p>instanacia de new Data con tolocale {new Date(task.date).toLocaleDateString()}</p>*/}
                     </li>
                   ))}


### PR DESCRIPTION
#45
con este pf se soluciona el bug de la fecha haciendo ajustes desde del front
se exige la fecha como dato obligatorio al crear una nueva tarea
se renderiza la fecha enviada desde el front ocupando un split en vez de métodos como toLocaleDateString()
se toma esta medita porque no queda claro si useForm envía la fecha en un formato string u objet, pero como sea el controlador en el servidor la gestiona como tipo date. y el dato recibido desde el servido es ocupado para una nueva instancia de Date (new Date) y se le aplica el método toLocaleDateString() al retorno de Date se obtiene como fecha un desfase de 1 día menos... luego de un tanteo se opto por la solución practica